### PR TITLE
Replace context function and add reply to email so tutors can reply

### DIFF
--- a/email.php
+++ b/email.php
@@ -43,7 +43,8 @@ if (!$course) {
 }
 $SESSION->block_course_contacts_lastcourse = $course->id;
 require_login($course);
-$context = get_context_instance(CONTEXT_COURSE, $courseid);
+$context = context_course::instance($courseid);
+
 
 // Get the email address for our contact.
 if ($touid <= 0) {
@@ -80,8 +81,9 @@ if ($form->is_cancelled()) {
     $email = $data;
     $email->message = $email->message['text'];
     $result = false;
+
     if ($data->mailto == $mailto->email && $data->cid == $courseid) {
-        $result = email_to_user($mailto, $USER, $email->subject, strip_tags($email->message), $email->message);
+		$result = email_to_user($mailto, $USER, $email->subject, strip_tags($email->message), $email->message, NULL, NULL, NULL, $USER->email, NULL, NULL);
     } else {
         // debugging($data->mailto.' == '.$mailto->email);
         // debugging($data->cid.' == '.$courseid);

--- a/email.php
+++ b/email.php
@@ -83,7 +83,8 @@ if ($form->is_cancelled()) {
     $result = false;
 
     if ($data->mailto == $mailto->email && $data->cid == $courseid) {
-		$result = email_to_user($mailto, $USER, $email->subject, strip_tags($email->message), $email->message, NULL, NULL, NULL, $USER->email, NULL, NULL);
+        $result = email_to_user($mailto, $USER, $email->subject, strip_tags($email->message), 
+		                $email->message, null, null, null, $USER->email, null, null);
     } else {
         // debugging($data->mailto.' == '.$mailto->email);
         // debugging($data->cid.' == '.$courseid);

--- a/email.php
+++ b/email.php
@@ -83,8 +83,8 @@ if ($form->is_cancelled()) {
     $result = false;
 
     if ($data->mailto == $mailto->email && $data->cid == $courseid) {
-        $result = email_to_user($mailto, $USER, $email->subject, strip_tags($email->message), 
-		                $email->message, null, null, null, $USER->email, null, null);
+        $result = email_to_user($mailto, $USER, $email->subject, strip_tags($email->message),
+        $email->message, null, null, null, $USER->email, null, null);
     } else {
         // debugging($data->mailto.' == '.$mailto->email);
         // debugging($data->cid.' == '.$courseid);


### PR DESCRIPTION
We've had issues with tutors not being able to reply directly to emails as they were receiving them via the server's no reply address.

Have added a parameter to the email_to_user() function to allow for this to work - might not quite be the correct syntax as I was in a rush, but that seems ok.

Also replaced an old get_context_instance() function.