### PR TITLE
Add Moodle 4.5 (405) support

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -1,0 +1,36 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace block_course_contacts;
+
+/**
+ * Hook callbacks.
+ *
+ * @package     course_contacts
+ * @author      Alexander Van der Bellen <alexandervanderbellen@catalyst-au.net>
+ * @copyright   2025 Catalyst IT Australia
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class hook_callbacks {
+    /**
+     * Runs before HTTP headers.
+     *
+     * @param \core\hook\output\before_http_headers $hook
+     */
+    public static function before_http_headers(\core\hook\output\before_http_headers $hook): void {
+        block_course_contacts_before_http_headers();
+    }
+}

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -15,22 +15,20 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Block Course_Contacts version file.
+ * Hook callbacks.
  *
- * @package    block_course_contacts
- * @author     Mark Ward
- *             2020 Richard Oelmann
- * @copyright  Mark Ward
- * @copyright  2020 R. Oelmann
- *
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package     course_contacts
+ * @author      Alexander Van der Bellen <alexandervanderbellen@catalyst-au.net>
+ * @copyright   2025 Catalyst IT Australia
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-    $plugin->version = 2020050101;  // YYYYMMDDHH (year, month, day, 24-hr time).
-    $plugin->requires = 2019052000; // YYYYMMDDHH (This is the release version for Moodle 2.0).
-    $plugin->release = '3.9.0.1'; // Plugin release.
-    $plugin->maturity   = MATURITY_STABLE;
-    $plugin->component = 'block_course_contacts'; // Full name of the plugin (used for diagnostics).
-    $plugin->supported = [401, 405];
+$callbacks = [
+    [
+        'hook' => \core\hook\output\before_http_headers::class,
+        'callback' => '\block_course_contacts\hook_callbacks::before_http_headers',
+        'priority' => 0,
+    ],
+];


### PR DESCRIPTION
### Prerequisites
This merge request should be applied after https://github.com/roelmann/moodle-block_course_contacts/pull/36.

### Summary

The plugin requires the `before_http_headers` hook in order to be compatible with Moodle 4.5.

The hook calls the original function for backwards compatibility with 4.1.

### Testing

1. Install the plugin on Moodle 4.5 with both https://github.com/roelmann/moodle-block_course_contacts/pull/36 and this patch.
2. Add an instance of the block to a course with teachers.
3. Edit the block settings to show contact information for all teacher roles.
4. Verify it works correctly.
5. Verify the plugin admin settings page works correctly.